### PR TITLE
Update documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Better than curses/ncurses, here is Notty. Written in OCaml, this library
 is based on the notion of composable images.
 
   * [Notty on Github](https://github.com/pqwy/notty)
-  * [documentation](https://pqwy.github.io/notty/Notty.html)
+  * [documentation](http://pqwy.github.io/notty/doc/Notty.html)
 
 ## Basics
 


### PR DESCRIPTION
Just updated the URL since the the old is a 404. 👎🏻

Really appreciate the effort you put in here—it’s been super helpful while learning Notty. 😀

